### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,5 +1,9 @@
 name: Benchmarks
 
+permissions:
+  contents: read
+  pages: write
+
 on:
   workflow_dispatch:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/stevethedev/floatguard/security/code-scanning/5](https://github.com/stevethedev/floatguard/security/code-scanning/5)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the workflow's steps:
1. The `contents: read` permission is required for the `Checkout repository` step.
2. The `pages: write` permission is required for the `Deploy to GitHub Pages` step.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added specifically to the `benchmark` job. In this case, adding it at the root level is more concise and ensures consistency across all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
