### PR TITLE
Update benchmarks workflow permissions

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,7 +1,7 @@
 name: Benchmarks
 
 permissions:
-  contents: read
+  contents: write
   pages: write
 
 on:
@@ -21,6 +21,7 @@ concurrency:
 
 jobs:
   benchmark:
+    name: Benchmarks
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
This pull request updates the benchmarks workflow to grant write permissions for content, ensuring that the workflow functions correctly with updated requirements or dependencies.