### PR TITLE
Fix benchmarks workflow destination path and sanitize ref name

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -65,4 +65,4 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: target/criterion
           publish_branch: gh-pages
-          destination_dir: benchmarks/${{ get_sanitized_ref_name.outputs.sanitizedRefName }}
+          destination_dir: benchmarks/${{ steps.get_sanitized_ref_name.outputs.sanitizedRefName }}


### PR DESCRIPTION
- **Fixed** incorrect variable reference causing issues in benchmarks workflow's destination path.
- **Updated** to sanitize the ref name to ensure safe file paths handling