### PR TITLE
Refine ref name sanitization in benchmarks workflow

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Sanitize ref name
         id: get_sanitized_ref_name
         run: |
-          SANITIZED_REF_NAME=$(echo "${GITHUB_REF_NAME}" | tr -c '[:alnum:]' '-')
+          SANITIZED_REF_NAME=$(echo "${GITHUB_REF_NAME}" | tr -c '[:alnum:]' '-' | sed 's/-\+$//')
           echo "sanitizedRefName=${SANITIZED_REF_NAME}" >> $GITHUB_OUTPUT
 
       - name: Deploy to GitHub Pages


### PR DESCRIPTION
Refines the sanitization process for ref names in the benchmarks workflow to ensure trailing dashes are removed. This improves consistency in the generated names and prevents potential issues caused by unexpected characters.