### PR TITLE
Fix ref name sanitization in benchmarks workflow

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Sanitize ref name
         id: get_sanitized_ref_name
         run: |
-          SANITIZED_REF_NAME=$(echo "${GITHUB_REF_NAME}" | tr -c '[:alnum:]' '-' | sed 's/-\+$//')
+          SANITIZED_REF_NAME=$(printf "${{ github.ref_name }}" | tr -c '[:alnum:].' '-')
           echo "sanitizedRefName=${SANITIZED_REF_NAME}" >> $GITHUB_OUTPUT
 
       - name: Deploy to GitHub Pages

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -64,5 +64,5 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: target/criterion
-          publish_branch: gh-pages
-          destination_dir: benchmarks/${{ steps.get_sanitized_ref_name.outputs.sanitizedRefName }}
+          publish_branch: gh-pages-source
+          destination_dir: src/benchmarks/${{ steps.get_sanitized_ref_name.outputs.sanitizedRefName }}

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,37 @@
+name: GitHub Pages Build and Deploy
+
+permissions:
+  contents: write
+  pages: write
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - gh-pages-source
+
+concurrency:
+  group: gh-pages-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+
+      - name: Build static site
+        run: node scripts/build.mjs
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: dist
+          publish_branch: gh-pages-source

--- a/benches/cmp.rs
+++ b/benches/cmp.rs
@@ -18,43 +18,31 @@ macro_rules! bench {
 bench!(
     bench_cmp,
     "Ordering",
-    (
-        "f64",
-        |b| {
-            let lhs: f64 = std::hint::black_box(42.0);
-            let rhs: f64 = std::hint::black_box(2.0);
-            b.iter(|| lhs < rhs)
-        }
-    ),
-    (
-        "GuardedF64",
-        |b| {
-            let lhs = GuardedF64::new(std::hint::black_box(42.0)).unwrap();
-            let rhs = GuardedF64::new(std::hint::black_box(2.0)).unwrap();
-            b.iter(|| lhs < rhs)
-        }
-    )
+    ("f64", |b| {
+        let lhs: f64 = std::hint::black_box(42.0);
+        let rhs: f64 = std::hint::black_box(2.0);
+        b.iter(|| lhs < rhs)
+    }),
+    ("GuardedF64", |b| {
+        let lhs = GuardedF64::new(std::hint::black_box(42.0)).unwrap();
+        let rhs = GuardedF64::new(std::hint::black_box(2.0)).unwrap();
+        b.iter(|| lhs < rhs)
+    })
 );
 
 bench!(
     bench_eq,
     "Equality",
-    (
-        "f64::eq",
-        |b| {
-            let lhs: f64 = std::hint::black_box(42.0);
-            let rhs: f64 = std::hint::black_box(2.0);
-            b.iter(|| lhs == rhs)
-        }
-    ),
-    (
-        "GuardedF64::eq",
-        |b| {
-            let lhs = GuardedF64::new(std::hint::black_box(42.0)).unwrap();
-            let rhs = GuardedF64::new(std::hint::black_box(2.0)).unwrap();
-            b.iter(|| lhs == rhs)
-        }
-    )
+    ("f64::eq", |b| {
+        let lhs: f64 = std::hint::black_box(42.0);
+        let rhs: f64 = std::hint::black_box(2.0);
+        b.iter(|| lhs == rhs)
+    }),
+    ("GuardedF64::eq", |b| {
+        let lhs = GuardedF64::new(std::hint::black_box(42.0)).unwrap();
+        let rhs = GuardedF64::new(std::hint::black_box(2.0)).unwrap();
+        b.iter(|| lhs == rhs)
+    })
 );
 
 criterion_group!(benches, bench_cmp, bench_eq,);

--- a/benches/cmp.rs
+++ b/benches/cmp.rs
@@ -1,43 +1,61 @@
 use criterion::{Criterion, criterion_group, criterion_main};
 use floatguard::GuardedF64;
 
-fn bench_f64_cmp(c: &mut Criterion) {
-    c.bench_function("f64::gt", |b| {
-        let lhs: f64 = std::hint::black_box(42.0);
-        let rhs: f64 = std::hint::black_box(2.0);
-        b.iter(|| lhs > rhs);
-    });
+macro_rules! bench {
+    ($id:ident, $group:literal, $( ($bench:literal, $expr:expr) ),* ) => {
+        fn $id(c: &mut Criterion) {
+            let mut group = c.benchmark_group($group);
+
+            $(
+                group.bench_function($bench, $expr);
+            )*
+
+            group.finish();
+        }
+    };
 }
 
-fn bench_checked_cmp(c: &mut Criterion) {
-    c.bench_function("GuardedF64::gt", |b| {
-        let lhs = GuardedF64::new(std::hint::black_box(42.0)).unwrap();
-        let rhs = GuardedF64::new(std::hint::black_box(2.0)).unwrap();
-        b.iter(|| lhs > rhs)
-    });
-}
-
-fn bench_f64_eq(c: &mut Criterion) {
-    c.bench_function("f64::eq", |b| {
-        let lhs: f64 = std::hint::black_box(42.0);
-        let rhs: f64 = std::hint::black_box(2.0);
-        b.iter(|| lhs == rhs);
-    });
-}
-
-fn bench_checked_eq(c: &mut Criterion) {
-    c.bench_function("GuardedF64::eq", |b| {
-        let lhs = GuardedF64::new(std::hint::black_box(42.0)).unwrap();
-        let rhs = GuardedF64::new(std::hint::black_box(2.0)).unwrap();
-        b.iter(|| lhs == rhs)
-    });
-}
-
-criterion_group!(
-    benches,
-    bench_f64_cmp,
-    bench_checked_cmp,
-    bench_f64_eq,
-    bench_checked_eq,
+bench!(
+    bench_cmp,
+    "Ordering",
+    (
+        "f64",
+        |b| {
+            let lhs: f64 = std::hint::black_box(42.0);
+            let rhs: f64 = std::hint::black_box(2.0);
+            b.iter(|| lhs < rhs)
+        }
+    ),
+    (
+        "GuardedF64",
+        |b| {
+            let lhs = GuardedF64::new(std::hint::black_box(42.0)).unwrap();
+            let rhs = GuardedF64::new(std::hint::black_box(2.0)).unwrap();
+            b.iter(|| lhs < rhs)
+        }
+    )
 );
+
+bench!(
+    bench_eq,
+    "Equality",
+    (
+        "f64::eq",
+        |b| {
+            let lhs: f64 = std::hint::black_box(42.0);
+            let rhs: f64 = std::hint::black_box(2.0);
+            b.iter(|| lhs == rhs)
+        }
+    ),
+    (
+        "GuardedF64::eq",
+        |b| {
+            let lhs = GuardedF64::new(std::hint::black_box(42.0)).unwrap();
+            let rhs = GuardedF64::new(std::hint::black_box(2.0)).unwrap();
+            b.iter(|| lhs == rhs)
+        }
+    )
+);
+
+criterion_group!(benches, bench_cmp, bench_eq,);
 criterion_main!(benches);

--- a/benches/math.rs
+++ b/benches/math.rs
@@ -1,595 +1,465 @@
 use criterion::{Criterion, criterion_group, criterion_main};
 use floatguard::{GuardedF64, UnguardedF64};
 
-fn bench_f64_abs(c: &mut Criterion) {
-    c.bench_function("f64::abs", |b| {
+macro_rules! bench {
+    ($id:ident, $group:literal, $( ($bench:literal, $expr:expr) ),* ) => {
+        fn $id(c: &mut Criterion) {
+            let mut group = c.benchmark_group($group);
+
+            $(
+                group.bench_function($bench, $expr);
+            )*
+
+            group.finish();
+        }
+    };
+}
+
+bench!(
+    bench_abs,
+    "Absolute Value",
+    ("f64::abs", |b| {
         let value = std::hint::black_box(-42.0f64);
         b.iter(|| value.abs());
-    });
-}
-
-fn bench_checked_abs(c: &mut Criterion) {
-    c.bench_function("GuardedF64::abs", |b| {
+    }),
+    ("GuardedF64::abs", |b| {
         let value = std::hint::black_box(GuardedF64::new(-42.0f64).unwrap());
         b.iter(|| value.abs());
-    });
-}
-
-fn bench_unchecked_abs(c: &mut Criterion) {
-    c.bench_function("UnguardedF64::abs", |b| {
+    }),
+    ("UnguardedF64::abs", |b| {
         let value = std::hint::black_box(UnguardedF64::new(-42.0f64));
         b.iter(|| value.abs());
-    });
-}
+    })
+);
 
-fn bench_f64_signum(c: &mut Criterion) {
-    c.bench_function("f64::signum", |b| {
+bench!(
+    bench_signum,
+    "Signum",
+    ("f64::signum", |b| {
         let value = std::hint::black_box(-42.0f64);
         b.iter(|| value.signum());
-    });
-}
-
-fn bench_checked_signum(c: &mut Criterion) {
-    c.bench_function("GuardedF64::signum", |b| {
+    }),
+    ("GuardedF64::signum", |b| {
         let value = std::hint::black_box(GuardedF64::new(-42.0f64).unwrap());
         b.iter(|| value.signum());
-    });
-}
-
-fn bench_unchecked_signum(c: &mut Criterion) {
-    c.bench_function("UnguardedF64::signum", |b| {
+    }),
+    ("UnguardedF64::signum", |b| {
         let value = std::hint::black_box(UnguardedF64::new(-42.0f64));
         b.iter(|| value.signum());
-    });
-}
+    })
+);
 
-fn bench_f64_sqrt(c: &mut Criterion) {
-    c.bench_function("f64::sqrt", |b| {
+bench!(
+    bench_sqrt,
+    "Square Root",
+    ("f64::sqrt", |b| {
         let value = std::hint::black_box(42.0f64);
         b.iter(|| value.sqrt());
-    });
-}
-
-fn bench_checked_sqrt(c: &mut Criterion) {
-    c.bench_function("GuardedF64::sqrt", |b| {
+    }),
+    ("GuardedF64::sqrt", |b| {
         let value = std::hint::black_box(GuardedF64::new(42.0f64).unwrap());
         b.iter(|| value.sqrt());
-    });
-}
-
-fn bench_unchecked_sqrt(c: &mut Criterion) {
-    c.bench_function("UnguardedF64::sqrt", |b| {
+    }),
+    ("UnguardedF64::sqrt", |b| {
         let value = std::hint::black_box(UnguardedF64::new(42.0f64));
         b.iter(|| value.sqrt());
-    });
-}
+    })
+);
 
-fn bench_f64_recip(c: &mut Criterion) {
-    c.bench_function("f64::recip", |b| {
+bench!(
+    bench_recip,
+    "Reciprocal",
+    ("f64::recip", |b| {
         let value = std::hint::black_box(42.0f64);
         b.iter(|| value.recip());
-    });
-}
-
-fn bench_checked_recip(c: &mut Criterion) {
-    c.bench_function("GuardedF64::recip", |b| {
+    }),
+    ("GuardedF64::recip", |b| {
         let value = std::hint::black_box(GuardedF64::new(42.0f64).unwrap());
         b.iter(|| value.recip());
-    });
-}
-
-fn bench_unchecked_recip(c: &mut Criterion) {
-    c.bench_function("UnguardedF64::recip", |b| {
+    }),
+    ("UnguardedF64::recip", |b| {
         let value = std::hint::black_box(UnguardedF64::new(42.0f64));
         b.iter(|| value.recip());
-    });
-}
+    })
+);
 
-fn bench_f64_exp(c: &mut Criterion) {
-    c.bench_function("f64::exp", |b| {
+bench!(
+    bench_exp,
+    "Exponential",
+    ("f64::exp", |b| {
         let value = std::hint::black_box(42.0f64);
         b.iter(|| value.exp());
-    });
-}
-
-fn bench_checked_exp(c: &mut Criterion) {
-    c.bench_function("GuardedF64::exp", |b| {
+    }),
+    ("GuardedF64::exp", |b| {
         let value = std::hint::black_box(GuardedF64::new(42.0f64).unwrap());
         b.iter(|| value.exp());
-    });
-}
-
-fn bench_unchecked_exp(c: &mut Criterion) {
-    c.bench_function("UnguardedF64::exp", |b| {
+    }),
+    ("UnguardedF64::exp", |b| {
         let value = std::hint::black_box(UnguardedF64::new(42.0f64));
         b.iter(|| value.exp());
-    });
-}
+    })
+);
 
-fn bench_f64_ln(c: &mut Criterion) {
-    c.bench_function("f64::ln", |b| {
+bench!(
+    bench_ln,
+    "Natural Logarithm",
+    ("f64::ln", |b| {
         let value = std::hint::black_box(42.0f64);
         b.iter(|| value.ln());
-    });
-}
-
-fn bench_checked_ln(c: &mut Criterion) {
-    c.bench_function("GuardedF64::ln", |b| {
+    }),
+    ("GuardedF64::ln", |b| {
         let value = std::hint::black_box(GuardedF64::new(42.0f64).unwrap());
         b.iter(|| value.ln());
-    });
-}
-
-fn bench_unchecked_ln(c: &mut Criterion) {
-    c.bench_function("UnguardedF64::ln", |b| {
+    }),
+    ("UnguardedF64::ln", |b| {
         let value = std::hint::black_box(UnguardedF64::new(42.0f64));
         b.iter(|| value.ln());
-    });
-}
+    })
+);
 
-fn bench_f64_log2(c: &mut Criterion) {
-    c.bench_function("f64::log2", |b| {
+bench!(
+    bench_log2,
+    "Base-2 Logarithm",
+    ("f64::log2", |b| {
         let value = std::hint::black_box(42.0f64);
         b.iter(|| value.log2());
-    });
-}
-
-fn bench_checked_log2(c: &mut Criterion) {
-    c.bench_function("GuardedF64::log2", |b| {
+    }),
+    ("GuardedF64::log2", |b| {
         let value = std::hint::black_box(GuardedF64::new(42.0f64).unwrap());
         b.iter(|| value.log2());
-    });
-}
-
-fn bench_unchecked_log2(c: &mut Criterion) {
-    c.bench_function("UnguardedF64::log2", |b| {
+    }),
+    ("UnguardedF64::log2", |b| {
         let value = std::hint::black_box(UnguardedF64::new(42.0f64));
         b.iter(|| value.log2());
-    });
-}
+    })
+);
 
-fn bench_f64_log10(c: &mut Criterion) {
-    c.bench_function("f64::log10", |b| {
+bench!(
+    bench_log10,
+    "Base-10 Logarithm",
+    ("f64::log10", |b| {
         let value = std::hint::black_box(42.0f64);
         b.iter(|| value.log10());
-    });
-}
-
-fn bench_checked_log10(c: &mut Criterion) {
-    c.bench_function("GuardedF64::log10", |b| {
+    }),
+    ("GuardedF64::log10", |b| {
         let value = std::hint::black_box(GuardedF64::new(42.0f64).unwrap());
         b.iter(|| value.log10());
-    });
-}
-
-fn bench_unchecked_log10(c: &mut Criterion) {
-    c.bench_function("UnguardedF64::log10", |b| {
+    }),
+    ("UnguardedF64::log10", |b| {
         let value = std::hint::black_box(UnguardedF64::new(42.0f64));
         b.iter(|| value.log10());
-    });
-}
+    })
+);
 
-fn bench_f64_log(c: &mut Criterion) {
-    c.bench_function("f64::log", |b| {
+bench!(
+    bench_log,
+    "Base-N Logarithm",
+    ("f64::log", |b| {
         let value = std::hint::black_box(42.0f64);
         let base = std::hint::black_box(2.0);
         b.iter(|| value.log(base));
-    });
-}
-
-fn bench_checked_log(c: &mut Criterion) {
-    c.bench_function("GuardedF64::log", |b| {
+    }),
+    ("GuardedF64::log", |b| {
         let value = std::hint::black_box(GuardedF64::new(42.0f64).unwrap());
         let base = std::hint::black_box(2.0);
         b.iter(|| value.log(base));
-    });
-}
-
-fn bench_unchecked_log(c: &mut Criterion) {
-    c.bench_function("UnguardedF64::log", |b| {
+    }),
+    ("UnguardedF64::log", |b| {
         let value = std::hint::black_box(UnguardedF64::new(42.0f64));
         let base = std::hint::black_box(2.0);
         b.iter(|| value.log(base));
-    });
-}
+    })
+);
 
-fn bench_f64_powi(c: &mut Criterion) {
-    c.bench_function("f64::powi", |b| {
+bench!(
+    bench_powi,
+    "Integer Power",
+    ("f64::powi", |b| {
         let base = std::hint::black_box(42.0f64);
         let exp = std::hint::black_box(2);
         b.iter(|| base.powi(exp));
-    });
-}
-
-fn bench_checked_powi(c: &mut Criterion) {
-    c.bench_function("GuardedF64::powi", |b| {
+    }),
+    ("GuardedF64::powi", |b| {
         let base = std::hint::black_box(GuardedF64::new(42.0f64).unwrap());
         let exp = std::hint::black_box(2);
         b.iter(|| base.powi(exp));
-    });
-}
-
-fn bench_unchecked_powi(c: &mut Criterion) {
-    c.bench_function("UnguardedF64::powi", |b| {
+    }),
+    ("UnguardedF64::powi", |b| {
         let base = std::hint::black_box(UnguardedF64::new(42.0f64));
         let exp = std::hint::black_box(2);
         b.iter(|| base.powi(exp));
-    });
-}
+    })
+);
 
-fn bench_f64_powf(c: &mut Criterion) {
-    c.bench_function("f64::powf", |b| {
+bench!(
+    bench_powf,
+    "Floating Point Power",
+    ("f64::powf", |b| {
         let base = std::hint::black_box(42.0f64);
         let exp = std::hint::black_box(2.0);
         b.iter(|| base.powf(exp));
-    });
-}
-
-fn bench_checked_powf(c: &mut Criterion) {
-    c.bench_function("GuardedF64::powf", |b| {
+    }),
+    ("GuardedF64::powf", |b| {
         let base = std::hint::black_box(GuardedF64::new(42.0f64).unwrap());
         let exp = std::hint::black_box(2.0);
         b.iter(|| base.powf(exp));
-    });
-}
-
-fn bench_unchecked_powf(c: &mut Criterion) {
-    c.bench_function("UnguardedF64::powf", |b| {
+    }),
+    ("UnguardedF64::powf", |b| {
         let base = std::hint::black_box(UnguardedF64::new(42.0f64));
         let exp = std::hint::black_box(2.0);
         b.iter(|| base.powf(exp));
-    });
-}
+    })
+);
 
-fn bench_f64_sin(c: &mut Criterion) {
-    c.bench_function("f64::sin", |b| {
+bench!(
+    bench_sin,
+    "Sine",
+    ("f64::sin", |b| {
         let value = std::hint::black_box(42.0f64);
         b.iter(|| value.sin());
-    });
-}
-
-fn bench_checked_sin(c: &mut Criterion) {
-    c.bench_function("GuardedF64::sin", |b| {
+    }),
+    ("GuardedF64::sin", |b| {
         let value = std::hint::black_box(GuardedF64::new(42.0f64).unwrap());
         b.iter(|| value.sin());
-    });
-}
-
-fn bench_unchecked_sin(c: &mut Criterion) {
-    c.bench_function("UnguardedF64::sin", |b| {
+    }),
+    ("UnguardedF64::sin", |b| {
         let value = std::hint::black_box(UnguardedF64::new(42.0f64));
         b.iter(|| value.sin());
-    });
-}
+    })
+);
 
-fn bench_f64_asin(c: &mut Criterion) {
-    c.bench_function("f64::asin", |b| {
+bench!(
+    bench_asin,
+    "Arcsine",
+    ("f64::asin", |b| {
         let value = std::hint::black_box(0.5f64);
         b.iter(|| value.asin());
-    });
-}
-
-fn bench_checked_asin(c: &mut Criterion) {
-    c.bench_function("GuardedF64::asin", |b| {
+    }),
+    ("GuardedF64::asin", |b| {
         let value = std::hint::black_box(GuardedF64::new(0.5f64).unwrap());
         b.iter(|| value.asin());
-    });
-}
-
-fn bench_unchecked_asin(c: &mut Criterion) {
-    c.bench_function("UnguardedF64::asin", |b| {
+    }),
+    ("UnguardedF64::asin", |b| {
         let value = std::hint::black_box(UnguardedF64::new(0.5f64));
         b.iter(|| value.asin());
-    });
-}
+    })
+);
 
-fn bench_f64_sinh(c: &mut Criterion) {
-    c.bench_function("f64::sinh", |b| {
+bench!(
+    bench_sinh,
+    "Hyperbolic Sine",
+    ("f64::sinh", |b| {
         let value = std::hint::black_box(42.0f64);
         b.iter(|| value.sinh());
-    });
-}
-
-fn bench_checked_sinh(c: &mut Criterion) {
-    c.bench_function("GuardedF64::sinh", |b| {
+    }),
+    ("GuardedF64::sinh", |b| {
         let value = std::hint::black_box(GuardedF64::new(42.0f64).unwrap());
         b.iter(|| value.sinh());
-    });
-}
-
-fn bench_unchecked_sinh(c: &mut Criterion) {
-    c.bench_function("UnguardedF64::sinh", |b| {
+    }),
+    ("UnguardedF64::sinh", |b| {
         let value = std::hint::black_box(UnguardedF64::new(42.0f64));
         b.iter(|| value.sinh());
-    });
-}
+    })
+);
 
-fn bench_f64_asinh(c: &mut Criterion) {
-    c.bench_function("f64::asinh", |b| {
+bench!(
+    bench_asinh,
+    "Hyperbolic Arcsine",
+    ("f64::asinh", |b| {
         let value = std::hint::black_box(0.5f64);
         b.iter(|| value.asinh());
-    });
-}
-
-fn bench_checked_asinh(c: &mut Criterion) {
-    c.bench_function("GuardedF64::asinh", |b| {
+    }),
+    ("GuardedF64::asinh", |b| {
         let value = std::hint::black_box(GuardedF64::new(0.5f64).unwrap());
         b.iter(|| value.asinh());
-    });
-}
-
-fn bench_unchecked_asinh(c: &mut Criterion) {
-    c.bench_function("UnguardedF64::asinh", |b| {
+    }),
+    ("UnguardedF64::asinh", |b| {
         let value = std::hint::black_box(UnguardedF64::new(0.5f64));
         b.iter(|| value.asinh());
-    });
-}
+    })
+);
 
-fn bench_f64_cos(c: &mut Criterion) {
-    c.bench_function("f64::cos", |b| {
+bench!(
+    bench_cos,
+    "Cosine",
+    ("f64::cos", |b| {
         let value = std::hint::black_box(42.0f64);
         b.iter(|| value.cos());
-    });
-}
-
-fn bench_checked_cos(c: &mut Criterion) {
-    c.bench_function("GuardedF64::cos", |b| {
+    }),
+    ("GuardedF64::cos", |b| {
         let value = std::hint::black_box(GuardedF64::new(42.0f64).unwrap());
         b.iter(|| value.cos());
-    });
-}
-
-fn bench_unchecked_cos(c: &mut Criterion) {
-    c.bench_function("UnguardedF64::cos", |b| {
+    }),
+    ("UnguardedF64::cos", |b| {
         let value = std::hint::black_box(UnguardedF64::new(42.0f64));
         b.iter(|| value.cos());
-    });
-}
+    })
+);
 
-fn bench_f64_acos(c: &mut Criterion) {
-    c.bench_function("f64::acos", |b| {
+bench!(
+    bench_acos,
+    "Arccosine",
+    ("f64::acos", |b| {
         let value = std::hint::black_box(0.5f64);
         b.iter(|| value.acos());
-    });
-}
-
-fn bench_checked_acos(c: &mut Criterion) {
-    c.bench_function("GuardedF64::acos", |b| {
+    }),
+    ("GuardedF64::acos", |b| {
         let value = std::hint::black_box(GuardedF64::new(0.5f64).unwrap());
         b.iter(|| value.acos());
-    });
-}
-
-fn bench_unchecked_acos(c: &mut Criterion) {
-    c.bench_function("UnguardedF64::acos", |b| {
+    }),
+    ("UnguardedF64::acos", |b| {
         let value = std::hint::black_box(UnguardedF64::new(0.5f64));
         b.iter(|| value.acos());
-    });
-}
+    })
+);
 
-fn bench_f64_cosh(c: &mut Criterion) {
-    c.bench_function("f64::cosh", |b| {
+bench!(
+    bench_cosh,
+    "Hyperbolic Cosine",
+    ("f64::cosh", |b| {
         let value = std::hint::black_box(42.0f64);
         b.iter(|| value.cosh());
-    });
-}
-
-fn bench_checked_cosh(c: &mut Criterion) {
-    c.bench_function("GuardedF64::cosh", |b| {
+    }),
+    ("GuardedF64::cosh", |b| {
         let value = std::hint::black_box(GuardedF64::new(42.0f64).unwrap());
         b.iter(|| value.cosh());
-    });
-}
-
-fn bench_unchecked_cosh(c: &mut Criterion) {
-    c.bench_function("UnguardedF64::cosh", |b| {
+    }),
+    ("UnguardedF64::cosh", |b| {
         let value = std::hint::black_box(UnguardedF64::new(42.0f64));
         b.iter(|| value.cosh());
-    });
-}
+    })
+);
 
-fn bench_f64_acosh(c: &mut Criterion) {
-    c.bench_function("f64::acosh", |b| {
+bench!(
+    bench_acosh,
+    "Hyperbolic Arccosine",
+    ("f64::acosh", |b| {
         let value = std::hint::black_box(1.5f64);
         b.iter(|| value.acosh());
-    });
-}
-
-fn bench_checked_acosh(c: &mut Criterion) {
-    c.bench_function("GuardedF64::acosh", |b| {
+    }),
+    ("GuardedF64::acosh", |b| {
         let value = std::hint::black_box(GuardedF64::new(1.5f64).unwrap());
         b.iter(|| value.acosh());
-    });
-}
-
-fn bench_unchecked_acosh(c: &mut Criterion) {
-    c.bench_function("UnguardedF64::acosh", |b| {
+    }),
+    ("UnguardedF64::acosh", |b| {
         let value = std::hint::black_box(UnguardedF64::new(1.5f64));
         b.iter(|| value.acosh());
-    });
-}
+    })
+);
 
-fn bench_f64_tan(c: &mut Criterion) {
-    c.bench_function("f64::tan", |b| {
+bench!(
+    bench_tan,
+    "Tangent",
+    ("f64::tan", |b| {
         let value = std::hint::black_box(42.0f64);
         b.iter(|| value.tan());
-    });
-}
-
-fn bench_checked_tan(c: &mut Criterion) {
-    c.bench_function("GuardedF64::tan", |b| {
+    }),
+    ("GuardedF64::tan", |b| {
         let value = std::hint::black_box(GuardedF64::new(42.0f64).unwrap());
         b.iter(|| value.tan());
-    });
-}
-
-fn bench_unchecked_tan(c: &mut Criterion) {
-    c.bench_function("UnguardedF64::tan", |b| {
+    }),
+    ("UnguardedF64::tan", |b| {
         let value = std::hint::black_box(UnguardedF64::new(42.0f64));
         b.iter(|| value.tan());
-    });
-}
+    })
+);
 
-fn bench_f64_atan(c: &mut Criterion) {
-    c.bench_function("f64::atan", |b| {
+bench!(
+    bench_atan,
+    "Arctangent",
+    ("f64::atan", |b| {
         let value = std::hint::black_box(0.5f64);
         b.iter(|| value.atan());
-    });
-}
-
-fn bench_checked_atan(c: &mut Criterion) {
-    c.bench_function("GuardedF64::atan", |b| {
+    }),
+    ("GuardedF64::atan", |b| {
         let value = std::hint::black_box(GuardedF64::new(0.5f64).unwrap());
         b.iter(|| value.atan());
-    });
-}
-
-fn bench_unchecked_atan(c: &mut Criterion) {
-    c.bench_function("UnguardedF64::atan", |b| {
+    }),
+    ("UnguardedF64::atan", |b| {
         let value = std::hint::black_box(UnguardedF64::new(0.5f64));
         b.iter(|| value.atan());
-    });
-}
+    })
+);
 
-fn bench_f64_tanh(c: &mut Criterion) {
-    c.bench_function("f64::tanh", |b| {
+bench!(
+    bench_tanh,
+    "Hyperbolic Tangent",
+    ("f64::tanh", |b| {
         let value = std::hint::black_box(42.0f64);
         b.iter(|| value.tanh());
-    });
-}
-
-fn bench_checked_tanh(c: &mut Criterion) {
-    c.bench_function("GuardedF64::tanh", |b| {
+    }),
+    ("GuardedF64::tanh", |b| {
         let value = std::hint::black_box(GuardedF64::new(42.0f64).unwrap());
         b.iter(|| value.tanh());
-    });
-}
-
-fn bench_unchecked_tanh(c: &mut Criterion) {
-    c.bench_function("UnguardedF64::tanh", |b| {
+    }),
+    ("UnguardedF64::tanh", |b| {
         let value = std::hint::black_box(UnguardedF64::new(42.0f64));
         b.iter(|| value.tanh());
-    });
-}
+    })
+);
 
-fn bench_f64_atanh(c: &mut Criterion) {
-    c.bench_function("f64::atanh", |b| {
+bench!(
+    bench_atanh,
+    "Hyperbolic Arctangent",
+    ("f64::atanh", |b| {
         let value = std::hint::black_box(0.5f64);
         b.iter(|| value.atanh());
-    });
-}
-
-fn bench_checked_atanh(c: &mut Criterion) {
-    c.bench_function("GuardedF64::atanh", |b| {
+    }),
+    ("GuardedF64::atanh", |b| {
         let value = std::hint::black_box(GuardedF64::new(0.5f64).unwrap());
         b.iter(|| value.atanh());
-    });
-}
-
-fn bench_unchecked_atanh(c: &mut Criterion) {
-    c.bench_function("UnguardedF64::atanh", |b| {
+    }),
+    ("UnguardedF64::atanh", |b| {
         let value = std::hint::black_box(UnguardedF64::new(0.5f64));
         b.iter(|| value.atanh());
-    });
-}
+    })
+);
 
-fn bench_f64_atan2(c: &mut Criterion) {
-    c.bench_function("f64::atan2", |b| {
+bench!(
+    bench_atan2,
+    "Arctangent2",
+    ("f64::atan2", |b| {
         let y = std::hint::black_box(1.0f64);
         let x = std::hint::black_box(0.5f64);
         b.iter(|| y.atan2(x));
-    });
-}
-
-fn bench_checked_atan2(c: &mut Criterion) {
-    c.bench_function("GuardedF64::atan2", |b| {
+    }),
+    ("GuardedF64::atan2", |b| {
         let y = std::hint::black_box(GuardedF64::new(1.0f64).unwrap());
         let x = std::hint::black_box(GuardedF64::new(0.5f64).unwrap());
         b.iter(|| y.atan2(x));
-    });
-}
-
-fn bench_unchecked_atan2(c: &mut Criterion) {
-    c.bench_function("UnguardedF64::atan2", |b| {
+    }),
+    ("UnguardedF64::atan2", |b| {
         let y = std::hint::black_box(UnguardedF64::new(1.0f64));
         let x = std::hint::black_box(UnguardedF64::new(0.5f64));
         b.iter(|| y.atan2(x));
-    });
-}
+    })
+);
 
 criterion_group!(
     benches,
-    bench_f64_abs,
-    bench_checked_abs,
-    bench_unchecked_abs,
-    bench_f64_signum,
-    bench_checked_signum,
-    bench_unchecked_signum,
-    bench_f64_sqrt,
-    bench_checked_sqrt,
-    bench_unchecked_sqrt,
-    bench_f64_recip,
-    bench_checked_recip,
-    bench_unchecked_recip,
-    bench_f64_exp,
-    bench_checked_exp,
-    bench_unchecked_exp,
-    bench_f64_ln,
-    bench_checked_ln,
-    bench_unchecked_ln,
-    bench_f64_log2,
-    bench_checked_log2,
-    bench_unchecked_log2,
-    bench_f64_log10,
-    bench_checked_log10,
-    bench_unchecked_log10,
-    bench_f64_log,
-    bench_checked_log,
-    bench_unchecked_log,
-    bench_f64_powi,
-    bench_checked_powi,
-    bench_unchecked_powi,
-    bench_f64_powf,
-    bench_checked_powf,
-    bench_unchecked_powf,
-    bench_f64_sin,
-    bench_checked_sin,
-    bench_unchecked_sin,
-    bench_f64_asin,
-    bench_checked_asin,
-    bench_unchecked_asin,
-    bench_f64_sinh,
-    bench_checked_sinh,
-    bench_unchecked_sinh,
-    bench_f64_asinh,
-    bench_checked_asinh,
-    bench_unchecked_asinh,
-    bench_f64_cos,
-    bench_checked_cos,
-    bench_unchecked_cos,
-    bench_f64_acos,
-    bench_checked_acos,
-    bench_unchecked_acos,
-    bench_f64_cosh,
-    bench_checked_cosh,
-    bench_unchecked_cosh,
-    bench_f64_acosh,
-    bench_checked_acosh,
-    bench_unchecked_acosh,
-    bench_f64_tan,
-    bench_checked_tan,
-    bench_unchecked_tan,
-    bench_f64_atan,
-    bench_checked_atan,
-    bench_unchecked_atan,
-    bench_f64_tanh,
-    bench_checked_tanh,
-    bench_unchecked_tanh,
-    bench_f64_atanh,
-    bench_checked_atanh,
-    bench_unchecked_atanh,
-    bench_f64_atan2,
-    bench_checked_atan2,
-    bench_unchecked_atan2,
+    bench_abs,
+    bench_signum,
+    bench_sqrt,
+    bench_recip,
+    bench_exp,
+    bench_ln,
+    bench_log2,
+    bench_log10,
+    bench_log,
+    bench_powi,
+    bench_powf,
+    bench_sin,
+    bench_asin,
+    bench_sinh,
+    bench_asinh,
+    bench_cos,
+    bench_acos,
+    bench_cosh,
+    bench_acosh,
+    bench_tan,
+    bench_atan,
+    bench_tanh,
+    bench_atanh,
+    bench_atan2,
 );
 criterion_main!(benches);

--- a/benches/ops_binary.rs
+++ b/benches/ops_binary.rs
@@ -18,154 +18,104 @@ macro_rules! bench {
 bench!(
     bench_add,
     "Addition",
-    (
-        "f64::add",
-        |b| {
-            let lhs = std::hint::black_box(42.0f64);
-            let rhs = std::hint::black_box(2.0);
-            b.iter(|| lhs + rhs)
-        }
-    ),
-    (
-        "GuardedF64::add",
-        |b| {
-            let lhs = GuardedF64::new(std::hint::black_box(42.0f64)).unwrap();
-            let rhs = GuardedF64::new(std::hint::black_box(2.0)).unwrap();
-            b.iter(|| lhs + rhs)
-        }
-    ),
-    (
-        "UnguardedF64::add",
-        |b| {
-            let lhs = UnguardedF64::new(std::hint::black_box(42.0f64));
-            let rhs = UnguardedF64::new(std::hint::black_box(2.0));
-            b.iter(|| lhs + rhs)
-        }
-    )
+    ("f64::add", |b| {
+        let lhs = std::hint::black_box(42.0f64);
+        let rhs = std::hint::black_box(2.0);
+        b.iter(|| lhs + rhs)
+    }),
+    ("GuardedF64::add", |b| {
+        let lhs = GuardedF64::new(std::hint::black_box(42.0f64)).unwrap();
+        let rhs = GuardedF64::new(std::hint::black_box(2.0)).unwrap();
+        b.iter(|| lhs + rhs)
+    }),
+    ("UnguardedF64::add", |b| {
+        let lhs = UnguardedF64::new(std::hint::black_box(42.0f64));
+        let rhs = UnguardedF64::new(std::hint::black_box(2.0));
+        b.iter(|| lhs + rhs)
+    })
 );
 
 bench!(
     bench_sub,
     "Subtraction",
-    (
-        "f64::sub",
-        |b| {
-            let lhs = std::hint::black_box(42.0f64);
-            let rhs = std::hint::black_box(2.0);
-            b.iter(|| lhs - rhs)
-        }
-    ),
-    (
-        "GuardedF64::sub",
-        |b| {
-            let lhs = GuardedF64::new(std::hint::black_box(42.0f64)).unwrap();
-            let rhs = GuardedF64::new(std::hint::black_box(2.0)).unwrap();
-            b.iter(|| lhs - rhs)
-        }
-    ),
-    (
-        "UnguardedF64::sub",
-        |b| {
-            let lhs = UnguardedF64::new(std::hint::black_box(42.0f64));
-            let rhs = UnguardedF64::new(std::hint::black_box(2.0));
-            b.iter(|| lhs - rhs)
-        }
-    )
+    ("f64::sub", |b| {
+        let lhs = std::hint::black_box(42.0f64);
+        let rhs = std::hint::black_box(2.0);
+        b.iter(|| lhs - rhs)
+    }),
+    ("GuardedF64::sub", |b| {
+        let lhs = GuardedF64::new(std::hint::black_box(42.0f64)).unwrap();
+        let rhs = GuardedF64::new(std::hint::black_box(2.0)).unwrap();
+        b.iter(|| lhs - rhs)
+    }),
+    ("UnguardedF64::sub", |b| {
+        let lhs = UnguardedF64::new(std::hint::black_box(42.0f64));
+        let rhs = UnguardedF64::new(std::hint::black_box(2.0));
+        b.iter(|| lhs - rhs)
+    })
 );
 
 bench!(
     bench_mul,
     "Multiplication",
-    (
-        "f64::mul",
-        |b| {
-            let lhs = std::hint::black_box(42.0f64);
-            let rhs = std::hint::black_box(2.0);
-            b.iter(|| lhs * rhs)
-        }
-    ),
-    (
-        "GuardedF64::mul",
-        |b| {
-            let lhs = GuardedF64::new(std::hint::black_box(42.0f64)).unwrap();
-            let rhs = GuardedF64::new(std::hint::black_box(2.0)).unwrap();
-            b.iter(|| lhs * rhs)
-        }
-    ),
-    (
-        "UnguardedF64::mul",
-        |b| {
-            let lhs = UnguardedF64::new(std::hint::black_box(42.0f64));
-            let rhs = UnguardedF64::new(std::hint::black_box(2.0));
-            b.iter(|| lhs * rhs)
-        }
-    )
+    ("f64::mul", |b| {
+        let lhs = std::hint::black_box(42.0f64);
+        let rhs = std::hint::black_box(2.0);
+        b.iter(|| lhs * rhs)
+    }),
+    ("GuardedF64::mul", |b| {
+        let lhs = GuardedF64::new(std::hint::black_box(42.0f64)).unwrap();
+        let rhs = GuardedF64::new(std::hint::black_box(2.0)).unwrap();
+        b.iter(|| lhs * rhs)
+    }),
+    ("UnguardedF64::mul", |b| {
+        let lhs = UnguardedF64::new(std::hint::black_box(42.0f64));
+        let rhs = UnguardedF64::new(std::hint::black_box(2.0));
+        b.iter(|| lhs * rhs)
+    })
 );
 
 bench!(
     bench_div,
     "Division",
-    (
-        "f64::div",
-        |b| {
-            let lhs = std::hint::black_box(42.0f64);
-            let rhs = std::hint::black_box(2.0);
-            b.iter(|| lhs / rhs)
-        }
-    ),
-    (
-        "GuardedF64::div",
-        |b| {
-            let lhs = GuardedF64::new(std::hint::black_box(42.0f64)).unwrap();
-            let rhs = GuardedF64::new(std::hint::black_box(2.0)).unwrap();
-            b.iter(|| lhs / rhs)
-        }
-    ),
-    (
-        "UnguardedF64::div",
-        |b| {
-            let lhs = UnguardedF64::new(std::hint::black_box(42.0f64));
-            let rhs = UnguardedF64::new(std::hint::black_box(2.0));
-            b.iter(|| lhs / rhs)
-        }
-    )
+    ("f64::div", |b| {
+        let lhs = std::hint::black_box(42.0f64);
+        let rhs = std::hint::black_box(2.0);
+        b.iter(|| lhs / rhs)
+    }),
+    ("GuardedF64::div", |b| {
+        let lhs = GuardedF64::new(std::hint::black_box(42.0f64)).unwrap();
+        let rhs = GuardedF64::new(std::hint::black_box(2.0)).unwrap();
+        b.iter(|| lhs / rhs)
+    }),
+    ("UnguardedF64::div", |b| {
+        let lhs = UnguardedF64::new(std::hint::black_box(42.0f64));
+        let rhs = UnguardedF64::new(std::hint::black_box(2.0));
+        b.iter(|| lhs / rhs)
+    })
 );
 
 bench!(
     bench_rem,
     "Remainder",
-    (
-        "f64::rem",
-        |b| {
-            let lhs = std::hint::black_box(42.0f64);
-            let rhs = std::hint::black_box(2.0);
-            b.iter(|| lhs % rhs)
-        }
-    ),
-    (
-        "GuardedF64::rem",
-        |b| {
-            let lhs = GuardedF64::new(std::hint::black_box(42.0f64)).unwrap();
-            let rhs = GuardedF64::new(std::hint::black_box(2.0)).unwrap();
-            b.iter(|| lhs % rhs)
-        }
-    ),
-    (
-        "UnguardedF64::rem",
-        |b| {
-            let lhs = UnguardedF64::new(std::hint::black_box(42.0f64));
-            let rhs = UnguardedF64::new(std::hint::black_box(2.0));
-            b.iter(|| lhs % rhs)
-        }
-    )
+    ("f64::rem", |b| {
+        let lhs = std::hint::black_box(42.0f64);
+        let rhs = std::hint::black_box(2.0);
+        b.iter(|| lhs % rhs)
+    }),
+    ("GuardedF64::rem", |b| {
+        let lhs = GuardedF64::new(std::hint::black_box(42.0f64)).unwrap();
+        let rhs = GuardedF64::new(std::hint::black_box(2.0)).unwrap();
+        b.iter(|| lhs % rhs)
+    }),
+    ("UnguardedF64::rem", |b| {
+        let lhs = UnguardedF64::new(std::hint::black_box(42.0f64));
+        let rhs = UnguardedF64::new(std::hint::black_box(2.0));
+        b.iter(|| lhs % rhs)
+    })
 );
 
 criterion_group!(
-    benches,
-    bench_add,
-    bench_sub,
-    bench_mul,
-    bench_div,
-    bench_rem,
+    benches, bench_add, bench_sub, bench_mul, bench_div, bench_rem,
 );
 criterion_main!(benches);

--- a/benches/ops_binary.rs
+++ b/benches/ops_binary.rs
@@ -1,157 +1,171 @@
 use criterion::{Criterion, criterion_group, criterion_main};
 use floatguard::{GuardedF64, UnguardedF64};
 
-fn bench_f64_add(c: &mut Criterion) {
-    c.bench_function("f64::add", |b| {
-        let lhs = std::hint::black_box(42.0f64);
-        let rhs = std::hint::black_box(2.0);
+macro_rules! bench {
+    ($id:ident, $group:literal, $( ($bench:literal, $expr:expr) ),* ) => {
+        fn $id(c: &mut Criterion) {
+            let mut group = c.benchmark_group($group);
 
-        b.iter(|| lhs + rhs);
-    });
+            $(
+                group.bench_function($bench, $expr);
+            )*
+
+            group.finish();
+        }
+    };
 }
 
-fn bench_checked_add(c: &mut Criterion) {
-    c.bench_function("GuardedF64::add", |b| {
-        let lhs = std::hint::black_box(GuardedF64::new(42.0f64).unwrap());
-        let rhs = std::hint::black_box(GuardedF64::new(2.0).unwrap());
+bench!(
+    bench_add,
+    "Addition",
+    (
+        "f64::add",
+        |b| {
+            let lhs = std::hint::black_box(42.0f64);
+            let rhs = std::hint::black_box(2.0);
+            b.iter(|| lhs + rhs)
+        }
+    ),
+    (
+        "GuardedF64::add",
+        |b| {
+            let lhs = GuardedF64::new(std::hint::black_box(42.0f64)).unwrap();
+            let rhs = GuardedF64::new(std::hint::black_box(2.0)).unwrap();
+            b.iter(|| lhs + rhs)
+        }
+    ),
+    (
+        "UnguardedF64::add",
+        |b| {
+            let lhs = UnguardedF64::new(std::hint::black_box(42.0f64));
+            let rhs = UnguardedF64::new(std::hint::black_box(2.0));
+            b.iter(|| lhs + rhs)
+        }
+    )
+);
 
-        b.iter(|| lhs + rhs)
-    });
-}
+bench!(
+    bench_sub,
+    "Subtraction",
+    (
+        "f64::sub",
+        |b| {
+            let lhs = std::hint::black_box(42.0f64);
+            let rhs = std::hint::black_box(2.0);
+            b.iter(|| lhs - rhs)
+        }
+    ),
+    (
+        "GuardedF64::sub",
+        |b| {
+            let lhs = GuardedF64::new(std::hint::black_box(42.0f64)).unwrap();
+            let rhs = GuardedF64::new(std::hint::black_box(2.0)).unwrap();
+            b.iter(|| lhs - rhs)
+        }
+    ),
+    (
+        "UnguardedF64::sub",
+        |b| {
+            let lhs = UnguardedF64::new(std::hint::black_box(42.0f64));
+            let rhs = UnguardedF64::new(std::hint::black_box(2.0));
+            b.iter(|| lhs - rhs)
+        }
+    )
+);
 
-fn bench_unchecked_add(c: &mut Criterion) {
-    c.bench_function("UnguardedF64::add", |b| {
-        let lhs = std::hint::black_box(UnguardedF64::new(42.0f64));
-        let rhs = std::hint::black_box(UnguardedF64::new(2.0));
+bench!(
+    bench_mul,
+    "Multiplication",
+    (
+        "f64::mul",
+        |b| {
+            let lhs = std::hint::black_box(42.0f64);
+            let rhs = std::hint::black_box(2.0);
+            b.iter(|| lhs * rhs)
+        }
+    ),
+    (
+        "GuardedF64::mul",
+        |b| {
+            let lhs = GuardedF64::new(std::hint::black_box(42.0f64)).unwrap();
+            let rhs = GuardedF64::new(std::hint::black_box(2.0)).unwrap();
+            b.iter(|| lhs * rhs)
+        }
+    ),
+    (
+        "UnguardedF64::mul",
+        |b| {
+            let lhs = UnguardedF64::new(std::hint::black_box(42.0f64));
+            let rhs = UnguardedF64::new(std::hint::black_box(2.0));
+            b.iter(|| lhs * rhs)
+        }
+    )
+);
 
-        b.iter(|| lhs + rhs)
-    });
-}
+bench!(
+    bench_div,
+    "Division",
+    (
+        "f64::div",
+        |b| {
+            let lhs = std::hint::black_box(42.0f64);
+            let rhs = std::hint::black_box(2.0);
+            b.iter(|| lhs / rhs)
+        }
+    ),
+    (
+        "GuardedF64::div",
+        |b| {
+            let lhs = GuardedF64::new(std::hint::black_box(42.0f64)).unwrap();
+            let rhs = GuardedF64::new(std::hint::black_box(2.0)).unwrap();
+            b.iter(|| lhs / rhs)
+        }
+    ),
+    (
+        "UnguardedF64::div",
+        |b| {
+            let lhs = UnguardedF64::new(std::hint::black_box(42.0f64));
+            let rhs = UnguardedF64::new(std::hint::black_box(2.0));
+            b.iter(|| lhs / rhs)
+        }
+    )
+);
 
-fn bench_f64_sub(c: &mut Criterion) {
-    c.bench_function("f64::sub", |b| {
-        let lhs = std::hint::black_box(42.0f64);
-        let rhs = std::hint::black_box(2.0);
-
-        b.iter(|| lhs - rhs);
-    });
-}
-
-fn bench_checked_sub(c: &mut Criterion) {
-    c.bench_function("GuardedF64::sub", |b| {
-        let lhs = std::hint::black_box(GuardedF64::new(42.0f64).unwrap());
-        let rhs = std::hint::black_box(GuardedF64::new(2.0).unwrap());
-
-        b.iter(|| lhs - rhs)
-    });
-}
-
-fn bench_unchecked_sub(c: &mut Criterion) {
-    c.bench_function("UnguardedF64::sub", |b| {
-        let lhs = std::hint::black_box(UnguardedF64::new(42.0f64));
-        let rhs = std::hint::black_box(UnguardedF64::new(2.0));
-
-        b.iter(|| lhs + rhs)
-    });
-}
-
-fn bench_f64_mul(c: &mut Criterion) {
-    c.bench_function("f64::mul", |b| {
-        let lhs = std::hint::black_box(42.0f64);
-        let rhs = std::hint::black_box(2.0);
-
-        b.iter(|| lhs * rhs);
-    });
-}
-
-fn bench_checked_mul(c: &mut Criterion) {
-    c.bench_function("GuardedF64::mul", |b| {
-        let lhs = std::hint::black_box(GuardedF64::new(42.0f64).unwrap());
-        let rhs = std::hint::black_box(GuardedF64::new(2.0).unwrap());
-
-        b.iter(|| lhs * rhs)
-    });
-}
-
-fn bench_unchecked_mul(c: &mut Criterion) {
-    c.bench_function("UnguardedF64::mul", |b| {
-        let lhs = std::hint::black_box(UnguardedF64::new(42.0f64));
-        let rhs = std::hint::black_box(UnguardedF64::new(2.0));
-
-        b.iter(|| lhs * rhs)
-    });
-}
-
-fn bench_f64_div(c: &mut Criterion) {
-    c.bench_function("f64::div", |b| {
-        let lhs = std::hint::black_box(42.0f64);
-        let rhs = std::hint::black_box(2.0);
-
-        b.iter(|| lhs / rhs);
-    });
-}
-
-fn bench_checked_div(c: &mut Criterion) {
-    c.bench_function("GuardedF64::div", |b| {
-        let lhs = std::hint::black_box(GuardedF64::new(42.0f64).unwrap());
-        let rhs = std::hint::black_box(GuardedF64::new(2.0).unwrap());
-
-        b.iter(|| lhs / rhs)
-    });
-}
-
-fn bench_unchecked_div(c: &mut Criterion) {
-    c.bench_function("UnguardedF64::div", |b| {
-        let lhs = std::hint::black_box(UnguardedF64::new(42.0f64));
-        let rhs = std::hint::black_box(UnguardedF64::new(2.0));
-
-        b.iter(|| lhs / rhs)
-    });
-}
-
-fn bench_f64_rem(c: &mut Criterion) {
-    c.bench_function("f64::rem", |b| {
-        let lhs = std::hint::black_box(42.0f64);
-        let rhs = std::hint::black_box(2.0);
-
-        b.iter(|| lhs % rhs);
-    });
-}
-
-fn bench_checked_rem(c: &mut Criterion) {
-    c.bench_function("GuardedF64::rem", |b| {
-        let lhs = std::hint::black_box(GuardedF64::new(42.0f64).unwrap());
-        let rhs = std::hint::black_box(GuardedF64::new(2.0).unwrap());
-
-        b.iter(|| lhs % rhs)
-    });
-}
-
-fn bench_unchecked_rem(c: &mut Criterion) {
-    c.bench_function("UnguardedF64::rem", |b| {
-        let lhs = std::hint::black_box(UnguardedF64::new(42.0f64));
-        let rhs = std::hint::black_box(UnguardedF64::new(2.0));
-
-        b.iter(|| lhs % rhs)
-    });
-}
+bench!(
+    bench_rem,
+    "Remainder",
+    (
+        "f64::rem",
+        |b| {
+            let lhs = std::hint::black_box(42.0f64);
+            let rhs = std::hint::black_box(2.0);
+            b.iter(|| lhs % rhs)
+        }
+    ),
+    (
+        "GuardedF64::rem",
+        |b| {
+            let lhs = GuardedF64::new(std::hint::black_box(42.0f64)).unwrap();
+            let rhs = GuardedF64::new(std::hint::black_box(2.0)).unwrap();
+            b.iter(|| lhs % rhs)
+        }
+    ),
+    (
+        "UnguardedF64::rem",
+        |b| {
+            let lhs = UnguardedF64::new(std::hint::black_box(42.0f64));
+            let rhs = UnguardedF64::new(std::hint::black_box(2.0));
+            b.iter(|| lhs % rhs)
+        }
+    )
+);
 
 criterion_group!(
     benches,
-    bench_f64_add,
-    bench_checked_add,
-    bench_unchecked_add,
-    bench_f64_sub,
-    bench_checked_sub,
-    bench_unchecked_sub,
-    bench_f64_mul,
-    bench_checked_mul,
-    bench_unchecked_mul,
-    bench_f64_div,
-    bench_checked_div,
-    bench_unchecked_div,
-    bench_f64_rem,
-    bench_checked_rem,
-    bench_unchecked_rem,
+    bench_add,
+    bench_sub,
+    bench_mul,
+    bench_div,
+    bench_rem,
 );
 criterion_main!(benches);

--- a/benches/ops_unary.rs
+++ b/benches/ops_unary.rs
@@ -1,31 +1,48 @@
 use criterion::{Criterion, criterion_group, criterion_main};
 use floatguard::{GuardedF64, UnguardedF64};
 
-fn bench_f64_neg(c: &mut Criterion) {
-    c.bench_function("f64::neg", |b| {
-        let value = std::hint::black_box(42.0f64);
-        b.iter(|| -value);
-    });
+macro_rules! bench {
+    ($id:ident, $group:literal, $( ($bench:literal, $expr:expr) ),* ) => {
+        fn $id(c: &mut Criterion) {
+            let mut group = c.benchmark_group($group);
+
+            $(
+                group.bench_function($bench, $expr);
+            )*
+
+            group.finish();
+        }
+    };
 }
 
-fn bench_checked_neg(c: &mut Criterion) {
-    c.bench_function("GuardedF64::neg", |b| {
-        let value = std::hint::black_box(GuardedF64::new(42.0f64).unwrap());
-        b.iter(|| -value);
-    });
-}
-
-fn bench_unchecked_neg(c: &mut Criterion) {
-    c.bench_function("UnguardedF64::neg", |b| {
-        let value = std::hint::black_box(UnguardedF64::new(42.0f64));
-        b.iter(|| -value);
-    });
-}
+bench!(
+    bench_neg,
+    "Negation",
+    (
+        "f64::neg",
+        |b| {
+            let value = std::hint::black_box(42.0f64);
+            b.iter(|| -value)
+        }
+    ),
+    (
+        "GuardedF64::neg",
+        |b| {
+            let value = GuardedF64::new(std::hint::black_box(42.0f64)).unwrap();
+            b.iter(|| -value)
+        }
+    ),
+    (
+        "UnguardedF64::neg",
+        |b| {
+            let value = UnguardedF64::new(std::hint::black_box(42.0f64));
+            b.iter(|| -value)
+        }
+    )
+);
 
 criterion_group!(
     benches,
-    bench_f64_neg,
-    bench_checked_neg,
-    bench_unchecked_neg
+    bench_neg,
 );
 criterion_main!(benches);

--- a/benches/ops_unary.rs
+++ b/benches/ops_unary.rs
@@ -18,31 +18,19 @@ macro_rules! bench {
 bench!(
     bench_neg,
     "Negation",
-    (
-        "f64::neg",
-        |b| {
-            let value = std::hint::black_box(42.0f64);
-            b.iter(|| -value)
-        }
-    ),
-    (
-        "GuardedF64::neg",
-        |b| {
-            let value = GuardedF64::new(std::hint::black_box(42.0f64)).unwrap();
-            b.iter(|| -value)
-        }
-    ),
-    (
-        "UnguardedF64::neg",
-        |b| {
-            let value = UnguardedF64::new(std::hint::black_box(42.0f64));
-            b.iter(|| -value)
-        }
-    )
+    ("f64::neg", |b| {
+        let value = std::hint::black_box(42.0f64);
+        b.iter(|| -value)
+    }),
+    ("GuardedF64::neg", |b| {
+        let value = GuardedF64::new(std::hint::black_box(42.0f64)).unwrap();
+        b.iter(|| -value)
+    }),
+    ("UnguardedF64::neg", |b| {
+        let value = UnguardedF64::new(std::hint::black_box(42.0f64));
+        b.iter(|| -value)
+    })
 );
 
-criterion_group!(
-    benches,
-    bench_neg,
-);
+criterion_group!(benches, bench_neg,);
 criterion_main!(benches);

--- a/src/guarded_f64/eager/cmp.rs
+++ b/src/guarded_f64/eager/cmp.rs
@@ -30,6 +30,8 @@ impl PartialEq for GuardedF64 {
     }
 }
 
+impl Eq for GuardedF64 {}
+
 impl PartialEq<f64> for GuardedF64 {
     /// Compares `GuardedF64` with `f64` for equality.
     ///
@@ -99,7 +101,35 @@ impl PartialOrd for GuardedF64 {
     /// assert_eq!(a >= b, false);
     /// ```
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        PartialOrd::partial_cmp(&self.0, &other.0)
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for GuardedF64 {
+    /// Compares two `GuardedF64` values.
+    ///
+    /// # Returns
+    ///
+    /// Returns `Ordering` if both values are valid (finite), otherwise panics.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use floatguard::GuardedF64;
+    ///
+    /// let a = GuardedF64::new(2.0).unwrap();
+    /// let b = GuardedF64::new(3.0).unwrap();
+    /// assert_eq!(a.cmp(&b), std::cmp::Ordering::Less);
+    /// ```
+    fn cmp(&self, other: &Self) -> Ordering {
+        let lhs = self.0;
+        let rhs = other.0;
+
+        match (lhs < rhs, lhs > rhs) {
+            (true, _) => Ordering::Less,
+            (_, true) => Ordering::Greater,
+            _ => Ordering::Equal,
+        }
     }
 }
 


### PR DESCRIPTION
Ensure ref name retains dots in benchmarks workflow by fixing the sanitization logic.