### PR TITLE
[Knope] Version v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
----
-default: patch
----
+## 0.1.1 (2025-07-11)
 
-# Implemented `Eq` and `Cmp` for `GuardedF64`
+### Fixes
+
+#### Implemented `Eq` and `Cmp` for `GuardedF64`
 
 Since `GuardedF64` is guaranteed to be non-NaN and finite, it is now safe to implement `Eq` and `Ord` traits for it.
 This allows for strict comparisons between `GuardedF64` values, which can be useful in various contexts where ordering

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,7 +208,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "floatguard"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "criterion",
  "proptest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floatguard"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 authors = ["Steven Jimenez <stevenmjimenez@gmail.com>"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Merging this PR will release the following:


## Fixes

### Implemented `Eq` and `Cmp` for `GuardedF64`

Since `GuardedF64` is guaranteed to be non-NaN and finite, it is now safe to implement `Eq` and `Ord` traits for it.
This allows for strict comparisons between `GuardedF64` values, which can be useful in various contexts where ordering
or equality checks are necessary.