### PR TITLE
Switch to `cargo-binstall` for CI third-party tool installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,13 +39,11 @@ jobs:
 
       - name: Add Cargo Third-Party Tools
         run: |
-          if ! command -v cargo-audit &> /dev/null; then
-            cargo install cargo-audit
+          if ! command -v cargo-binstall &> /dev/null; then
+            cargo install cargo-binstall
           fi
-          
-          if ! command -v cargo-tarpaulin &> /dev/null; then
-            cargo install cargo-tarpaulin
-          fi
+
+          cargo binstall cargo-audit cargo-tarpaulin --no-confirm
 
       - name: Check documentation
         run: cargo doc --no-deps --document-private-items

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-and-test:
     name: Build and Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,12 +37,13 @@ jobs:
             ~/.cargo/registry
             target
 
+      - name: Install cargo-binstall
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-binstall
+
       - name: Add Cargo Third-Party Tools
         run: |
-          if ! command -v cargo-binstall &> /dev/null; then
-            cargo install cargo-binstall
-          fi
-
           if ! command -v cargo-audit &> /dev/null; then
             cargo binstall cargo-audit --no-confirm
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,8 +43,13 @@ jobs:
             cargo install cargo-binstall
           fi
 
-          cargo binstall cargo-audit cargo-tarpaulin --no-confirm
+          if ! command -v cargo-audit &> /dev/null; then
+            cargo binstall cargo-audit --no-confirm
+          fi
 
+          if ! command -v cargo-tarpaulin &> /dev/null; then
+            cargo binstall cargo-tarpaulin --no-confirm
+          fi
       - name: Check documentation
         run: cargo doc --no-deps --document-private-items
 


### PR DESCRIPTION
This pull request simplifies the CI process by switching to `cargo-binstall` for installing third-party tools. This change improves efficiency and reduces complexity in the CI setup.