### PR TITLE
Update benchmark deployment workflow token and remove unused step

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -62,20 +62,7 @@ jobs:
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.BENCHMARK_GITHUB_TOKEN }}
           publish_dir: target/criterion
           publish_branch: gh-pages-source
           destination_dir: src/benchmarks/${{ steps.get_sanitized_ref_name.outputs.sanitizedRefName }}
-
-      - name: Trigger gh-pages workflow
-        uses: actions/github-script@v7
-        env:
-            GITHUB_TOKEN: ${{ secrets.BENCHMARK_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
-        with:
-          script: |
-            await github.rest.actions.createWorkflowDispatch({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              workflow_id: 'gh-pages.yml',
-              ref: 'gh-pages-script'
-            })


### PR DESCRIPTION
This pull request updates the benchmark deployment workflow by replacing the `GITHUB_TOKEN` with `BENCHMARK_GITHUB_TOKEN` to address potential security or functionality improvements. Additionally, an unused workflow dispatch step has been removed to streamline the process.